### PR TITLE
Review tsconfig settings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   testEnvironment: "node",
   transform: {
-    "^.+.tsx?$": ["ts-jest",{}],
+    "^.+.tsx?$": ["ts-jest",{ tsconfig: "tsconfig.test.json" }],
   },
   testMatch: ["**/*.test.ts", "**/*.spec.ts"],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "strict": true,
-    "jsx": "react",
     "declaration": true,
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ES2020"],
+    "rootDir": "./src",
     "outDir": "./dist",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*"]
-    }
+    "baseUrl": "./"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "verbatimModuleSyntax": false,
+    "rootDir": ".",
+    "outDir": "./.ts-test-dist"
+  }
+}
+

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,6 +6,8 @@
     "verbatimModuleSyntax": false,
     "rootDir": ".",
     "outDir": "./.ts-test-dist"
-  }
+  },
+  "include": ["src/**/*", "**/*.test.ts", "**/*.spec.ts"],
+  "exclude": ["node_modules", "dist"]
 }
 


### PR DESCRIPTION
Refactor `tsconfig.json` for library best practices and create `tsconfig.test.json` to ensure Jest compatibility with `verbatimModuleSyntax`.

The `verbatimModuleSyntax` option in `tsconfig.json` improves module resolution accuracy but conflicts with how Jest processes modules, specifically requiring `module: CommonJS`. Introducing a separate `tsconfig.test.json` allows the main `tsconfig.json` to maintain strictness for library builds while Jest can function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f45858c4-71d2-4bf0-b8db-01c8c817ec16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f45858c4-71d2-4bf0-b8db-01c8c817ec16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines TS build config and introduces a dedicated test tsconfig, updating Jest to use it.
> 
> - **Config**:
>   - **TypeScript (`tsconfig.json`)**:
>     - Retarget to `ES2020`, switch `moduleResolution` to `Bundler`, add `lib: ["ES2020"]`, `rootDir: ./src`, `forceConsistentCasingInFileNames`, and `verbatimModuleSyntax`.
>     - Remove `paths` mapping; keep `baseUrl`.
>   - **Testing**:
>     - Add `tsconfig.test.json` (extends main config) with `module: CommonJS`, `moduleResolution: Node`, `verbatimModuleSyntax: false`, `rootDir: .`, `outDir: ./.ts-test-dist`.
>     - Update `jest.config.js` to run `ts-jest` with `tsconfig: "tsconfig.test.json"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c444601161857b41df56e8e76cc6de4ae8c3628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->