### PR TITLE
Fix tsconfig test file exclusion bug

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,4 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "Node",


### PR DESCRIPTION
Remove `extends` from `tsconfig.test.json` to prevent it from inheriting `exclude` rules that blocked test file compilation.

The `tsconfig.test.json` was extending `tsconfig.json`, which explicitly excluded test files. This created a contradiction where `ts-jest` could not compile the necessary test files, leading to potential compilation failures. Making `tsconfig.test.json` standalone resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe031e9d-aee6-4d3e-8cb7-4e6f53c31b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe031e9d-aee6-4d3e-8cb7-4e6f53c31b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

